### PR TITLE
Allow white-on-black text/lines

### DIFF
--- a/lib/Display/DisplayTemplateDriver.cpp
+++ b/lib/Display/DisplayTemplateDriver.cpp
@@ -244,7 +244,9 @@ void DisplayTemplateDriver::loadTemplate(const String& templateFilename) {
     return;
   }
 
-  display->fillScreen(parseColor(tmpl["background_color"]));
+  uint16_t background_color = parseColor(tmpl["background_color"]);
+
+  display->fillScreen(background_color);
 
   if (tmpl.containsKey("rotation")) {
     display->setRotation(tmpl["rotation"]);
@@ -264,7 +266,7 @@ void DisplayTemplateDriver::loadTemplate(const String& templateFilename) {
   }
 
   if (tmpl.containsKey("text")) {
-    renderTexts(formatterFactory, updateRects, tmpl["text"].as<JsonArray>());
+    renderTexts(formatterFactory, updateRects, tmpl["text"].as<JsonArray>(), background_color);
   }
 
   if (tmpl.containsKey("rectangles")) {
@@ -371,7 +373,8 @@ void DisplayTemplateDriver::renderBitmaps(
 void DisplayTemplateDriver::renderTexts(
     VariableFormatterFactory& formatterFactory,
     JsonObject updateRects,
-    JsonArray texts) {
+    JsonArray texts,
+    uint16_t background_color) {
   for (size_t i = 0; i < texts.size(); i++) {
     JsonObject text = texts[i];
 
@@ -409,6 +412,7 @@ void DisplayTemplateDriver::renderTexts(
       std::shared_ptr<Region> region = addTextRegion(x,
           y,
           color,
+          background_color,
           font,
           textSize,
           formatter,
@@ -458,6 +462,7 @@ std::shared_ptr<Region> DisplayTemplateDriver::addBitmapRegion(uint16_t x,
 std::shared_ptr<Region> DisplayTemplateDriver::addTextRegion(uint16_t x,
     uint16_t y,
     uint16_t color,
+    uint16_t background_color,
     const GFXfont* font,
     uint8_t textSize,
     std::shared_ptr<const VariableFormatter> formatter,
@@ -469,6 +474,7 @@ std::shared_ptr<Region> DisplayTemplateDriver::addTextRegion(uint16_t x,
       y,
       nullptr,  // fixed bound -- deprecated
       color,
+      background_color,
       font,
       formatter,
       textSize,
@@ -511,10 +517,16 @@ const GFXfont* DisplayTemplateDriver::parseFont(const String& fontName) {
 const uint16_t DisplayTemplateDriver::parseColor(const String& colorName) {
   if (colorName.equalsIgnoreCase("black")) {
     return GxEPD_BLACK;
+  } else if (colorName.equalsIgnoreCase("dgrey")) {
+    return GxEPD_DARKGREY;
+  } else if (colorName.equalsIgnoreCase("lgrey")) {
+    return GxEPD_LIGHTGREY;
+  } else if (colorName.equalsIgnoreCase("yellow")) {
+    return GxEPD_YELLOW;
   } else if (colorName.equalsIgnoreCase("red")) {
     return GxEPD_RED;
   } else {
-    return GxEPD_WHITE;
+    return GxEPD_DARKGREY;
   }
 }
 

--- a/lib/Display/DisplayTemplateDriver.cpp
+++ b/lib/Display/DisplayTemplateDriver.cpp
@@ -517,13 +517,11 @@ const GFXfont* DisplayTemplateDriver::parseFont(const String& fontName) {
 const uint16_t DisplayTemplateDriver::parseColor(const String& colorName) {
   if (colorName.equalsIgnoreCase("black")) {
     return GxEPD_BLACK;
-  } else if (colorName.equalsIgnoreCase("dgrey")) {
-    return GxEPD_DARKGREY;
-  } else if (colorName.equalsIgnoreCase("lgrey")) {
-    return GxEPD_LIGHTGREY;
   } else if (colorName.equalsIgnoreCase("yellow")) {
     return GxEPD_YELLOW;
   } else if (colorName.equalsIgnoreCase("red")) {
+    return GxEPD_RED;
+  } else if (colorName.equalsIgnoreCase("color")) {
     return GxEPD_RED;
   } else {
     return GxEPD_WHITE;

--- a/lib/Display/DisplayTemplateDriver.cpp
+++ b/lib/Display/DisplayTemplateDriver.cpp
@@ -526,7 +526,7 @@ const uint16_t DisplayTemplateDriver::parseColor(const String& colorName) {
   } else if (colorName.equalsIgnoreCase("red")) {
     return GxEPD_RED;
   } else {
-    return GxEPD_DARKGREY;
+    return GxEPD_WHITE;
   }
 }
 

--- a/lib/Display/DisplayTemplateDriver.h
+++ b/lib/Display/DisplayTemplateDriver.h
@@ -116,7 +116,8 @@ class DisplayTemplateDriver {
                         JsonArray lines);
   void renderTexts(VariableFormatterFactory& formatterFactory,
                    JsonObject updateRects,
-                   JsonArray text);
+                   JsonArray text,
+                   uint16_t background_color);
   void renderBitmaps(VariableFormatterFactory& formatterFactory,
                      JsonArray bitmaps);
   void renderBitmap(const String& filename,
@@ -130,6 +131,7 @@ class DisplayTemplateDriver {
       uint16_t x,
       uint16_t y,
       uint16_t color,
+      uint16_t background_color,
       const GFXfont* font,
       uint8_t textSize,
       std::shared_ptr<const VariableFormatter> formatter,

--- a/lib/Display/TextRegion.cpp
+++ b/lib/Display/TextRegion.cpp
@@ -8,6 +8,7 @@ TextRegion::TextRegion(
   uint16_t y,
   std::shared_ptr<Rectangle> fixedBound,
   uint16_t color,
+  uint16_t background_color,
   const GFXfont* font,
   std::shared_ptr<const VariableFormatter> formatter,
   uint8_t size,
@@ -36,7 +37,7 @@ void TextRegion::render(GxEPD2_GFX* display) {
     this->currentBound.y,
     this->currentBound.w,
     this->currentBound.h,
-    GxEPD_WHITE
+    background_color
   );
 
   display->setTextColor(color);

--- a/lib/Display/TextRegion.cpp
+++ b/lib/Display/TextRegion.cpp
@@ -25,6 +25,7 @@ TextRegion::TextRegion(
   , currentBound({x, y, 0, 0})
   , previousBound({x, y, 0, 0})
   , size(size)
+  , background_color(background_color)
 { }
 
 TextRegion::~TextRegion() { }

--- a/lib/Display/TextRegion.h
+++ b/lib/Display/TextRegion.h
@@ -17,6 +17,7 @@ public:
     uint16_t y,
     std::shared_ptr<Rectangle> fixedBoundingBox,
     uint16_t color,
+    uint16_t background_color,
     const GFXfont* font,
     std::shared_ptr<const VariableFormatter> formatter,
     uint8_t size,
@@ -29,6 +30,8 @@ public:
 
 protected:
   const GFXfont* font;
+
+  uint16_t background_color;
 
   // Users can optionally manually specify a bounding rectangle.
   std::shared_ptr<Rectangle> fixedBound;

--- a/web/src/templates/schema.js
+++ b/web/src/templates/schema.js
@@ -152,7 +152,7 @@ const Definitions = {
   color: {
     title: "Color",
     type: "string",
-    enum: ["black", "dgrey", "lgrey", "white"]
+    enum: ["black", "white"]
   },
   storedBitmap: {
     type: "string"

--- a/web/src/templates/schema.js
+++ b/web/src/templates/schema.js
@@ -55,7 +55,8 @@ const LineFields = {
     x1: { $ref: "#/definitions/horizontalPosition" },
     x2: { $ref: "#/definitions/horizontalPosition" },
     y1: { $ref: "#/definitions/verticalPosition" },
-    y2: { $ref: "#/definitions/verticalPosition" }
+    y2: { $ref: "#/definitions/verticalPosition" },
+    color: { $ref: "#/definitions/color" },
   }
 };
 
@@ -80,6 +81,7 @@ const TextFields = {
     y: { $ref: "#/definitions/verticalPosition" },
     font: { $ref: "#/definitions/font" },
     font_size: { type: "integer", title: "Font Size" },
+    color: { $ref: "#/definitions/color" },
     value: { title: "Value", $ref: "#/definitions/valueChoice" }
   }
 };

--- a/web/src/templates/schema.js
+++ b/web/src/templates/schema.js
@@ -152,7 +152,7 @@ const Definitions = {
   color: {
     title: "Color",
     type: "string",
-    enum: ["black", "white"]
+    enum: ["black", "white", "red", "yellow"]
   },
   storedBitmap: {
     type: "string"

--- a/web/src/templates/schema.js
+++ b/web/src/templates/schema.js
@@ -152,7 +152,7 @@ const Definitions = {
   color: {
     title: "Color",
     type: "string",
-    enum: ["black", "white"]
+    enum: ["black", "dgrey", "lgrey", "white"]
   },
   storedBitmap: {
     type: "string"


### PR DESCRIPTION
This should also allow greys and Red/Yellow to be used, but as I do not have a display with any of those at this time, I can not test that. If you wish, I can remove that until one of us can test it properly :)

Or if you can think of a more elegant solution to expose the background color to the renderer, let me know!

I just thought this was the most straight-forward way to go about it, and I saw ~~no~~ very few issues during my tests, but I'd very much appreciate you poking it to see if something is awry.

(I did have one instance where it went back to the default white background behavior, but after a re-upload, I can't recreate the issue. Maybe I had something old left over at the time?)

Additionally, the preview color in the template editor will need some prodding.