### PR TITLE
Allow the change of bitmaps background color

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,6 +288,11 @@ You can resize a bitmap by clicking on the totally-intuitive-and-definitely-not-
 
 You can download a copy of the image by clicking on the "Download" icon (1st icon under "File" section).
 
+
+#### Colors
+
+A recent update [(v2.4.0)](https://github.com/sidoh/epaper_templates/releases/tag/v2.4.0) brought a way to bring very simple coloring to bitmaps. The 2 color limitation still applies, but you can change the "on" and "off" pixel colors to any color your display supports.
+
 # REST API
 
 The following RESTful routes are available:

--- a/lib/Display/BitmapRegion.cpp
+++ b/lib/Display/BitmapRegion.cpp
@@ -8,6 +8,7 @@ BitmapRegion::BitmapRegion(
   uint16_t w,
   uint16_t h,
   uint16_t color,
+  uint16_t background_color,
   std::shared_ptr<const VariableFormatter> formatter,
   uint16_t index
 ) : Region(variable, {x, y, w, h}, color, formatter, "b-" + String(index))
@@ -27,7 +28,7 @@ void BitmapRegion::render(GxEPD2_GFX* display) {
 
     file.close();
 
-    display->fillRect(boundingBox.x, boundingBox.y, boundingBox.w, boundingBox.h, GxEPD_WHITE);
+    display->fillRect(boundingBox.x, boundingBox.y, boundingBox.w, boundingBox.h, background_color);
     display->drawBitmap(boundingBox.x, boundingBox.y, bits, boundingBox.w, boundingBox.h, color);
   }
 }

--- a/lib/Display/BitmapRegion.h
+++ b/lib/Display/BitmapRegion.h
@@ -18,6 +18,7 @@ public:
     uint16_t w,
     uint16_t h,
     uint16_t color,
+    uint16_t background_color,
     std::shared_ptr<const VariableFormatter> formatter,
     uint16_t index
   );

--- a/lib/Display/DisplayTemplateDriver.h
+++ b/lib/Display/DisplayTemplateDriver.h
@@ -104,6 +104,7 @@ class DisplayTemplateDriver {
 #endif
 
   const uint16_t defaultColor = GxEPD_BLACK;
+  const uint16_t defaultBackgroundColor = GxEPD_WHITE;
   const GFXfont* defaultFont = &FreeSans9pt7b;
 
   void flushDirtyRegions(bool screenUpdates);
@@ -113,19 +114,22 @@ class DisplayTemplateDriver {
 
   void renderLines(JsonArray lines);
   void renderRectangles(VariableFormatterFactory& formatterFactory,
-                        JsonArray lines);
+                        JsonArray lines,
+                        uint16_t background_color);
   void renderTexts(VariableFormatterFactory& formatterFactory,
                    JsonObject updateRects,
                    JsonArray text,
                    uint16_t background_color);
   void renderBitmaps(VariableFormatterFactory& formatterFactory,
-                     JsonArray bitmaps);
+                     JsonArray bitmaps,
+                     uint16_t template_background);
   void renderBitmap(const String& filename,
                     uint16_t x,
                     uint16_t y,
                     uint16_t w,
                     uint16_t h,
-                    uint16_t color);
+                    uint16_t color,
+                    uint16_t background_color);
 
   std::shared_ptr<Region> addTextRegion(
       uint16_t x,
@@ -144,17 +148,20 @@ class DisplayTemplateDriver {
       uint16_t w,
       uint16_t h,
       uint16_t color,
+      uint16_t background_color,
       VariableFormatterFactory& formatterFactory,
       JsonObject spec,
       uint16_t index);
   std::shared_ptr<Region> addRectangleRegion(
       VariableFormatterFactory& formatterFactory,
       JsonObject spec,
-      uint16_t index);
+      uint16_t index,
+      uint16_t background_color);
 
   const uint16_t parseColor(const String& colorName);
   const GFXfont* parseFont(const String& fontName);
   const uint16_t extractColor(JsonObject spec);
+  const uint16_t extractBackgroundColor(JsonObject spec, uint16_t template_background);
   const uint8_t extractTextSize(JsonObject spec);
 
   static bool regionContainedIn(Rectangle& r,

--- a/lib/Display/RectangleRegion.cpp
+++ b/lib/Display/RectangleRegion.cpp
@@ -7,6 +7,7 @@ RectangleRegion::RectangleRegion(const String& variable,
     RectangleRegion::Dimension w,
     RectangleRegion::Dimension h,
     uint16_t color,
+    uint16_t background_color,
     std::shared_ptr<const VariableFormatter> formatter,
     FillStyle fillStyle,
     uint16_t index
@@ -16,6 +17,7 @@ RectangleRegion::RectangleRegion(const String& variable,
     , w(w)
     , h(h)
     , previousBoundingBox({x, y, 0, 0})
+    , background_color(background_color)
  {}
 
 RectangleRegion::~RectangleRegion() {}
@@ -34,7 +36,7 @@ void RectangleRegion::render(GxEPD2_GFX* display) {
       boundingBox.y,
       boundingBox.w,
       boundingBox.h,
-      GxEPD_WHITE);
+      background_color);
 
   if (fillStyle == FillStyle::FILLED) {
     display->writeFillRect(boundingBox.x, boundingBox.y, width, height, color);

--- a/lib/Display/RectangleRegion.h
+++ b/lib/Display/RectangleRegion.h
@@ -31,6 +31,7 @@ class RectangleRegion : public Region {
       Dimension width,
       Dimension height,
       uint16_t color,
+      uint16_t background_color,
       std::shared_ptr<const VariableFormatter> formatter,
       FillStyle fillStyle,
       uint16_t index
@@ -43,4 +44,5 @@ class RectangleRegion : public Region {
   const FillStyle fillStyle;
   const Dimension w, h;
   Rectangle previousBoundingBox;
+  uint16_t background_color;
 };

--- a/lib/Display/Region.h
+++ b/lib/Display/Region.h
@@ -77,6 +77,7 @@ protected:
   String variableValue;
   Rectangle boundingBox;
   uint16_t color;
+  uint16_t background_color;
   bool dirty;
   std::shared_ptr<const VariableFormatter> formatter;
   String id;

--- a/web/src/templates/SvgCanvas.jsx
+++ b/web/src/templates/SvgCanvas.jsx
@@ -146,11 +146,17 @@ const SvgRectangle = React.memo(
       return [className, style === "filled" ? "filled" : "outline"];
     }, [style, className]);
 
+    // The color prop for "filled" rectangles should define the color of the whole rectangle
+    // (appropriate prop is "fill").  For outline rectangles, should it's "stroke".
+    const colorProps = {
+      [style === "filled" ? "fill" : "stroke"]: color
+    };
+
     return (
       <rect
         ref={ref}
         {...{ x, y, width, height }}
-        stroke={color}
+        {...colorProps}
         className={classes.join(" ")}
         onClick={onClick}
       />

--- a/web/src/templates/SvgCanvas.jsx
+++ b/web/src/templates/SvgCanvas.jsx
@@ -167,6 +167,7 @@ const SvgBitmap = React.memo(
         w: width = 0,
         h: height = 0,
         color = "black",
+        background_color: backgroundColor = "white",
         value: valueDef
       },
       static: _static,
@@ -191,12 +192,13 @@ const SvgBitmap = React.memo(
               binData: x,
               width,
               height,
-              color
+              color,
+              backgroundColor
             })
           );
         });
       }
-    }, [file, color]);
+    }, [file, color, backgroundColor]);
 
     return (
       <>

--- a/web/src/templates/SvgCanvas.scss
+++ b/web/src/templates/SvgCanvas.scss
@@ -47,7 +47,8 @@
 
     rect.filled,
     rect.active.filled {
-      stroke-width: 0;
+      fill: #393;
+      stroke-width: 0px;
     }
 
     rect.selection {

--- a/web/src/templates/SvgCanvas.scss
+++ b/web/src/templates/SvgCanvas.scss
@@ -47,7 +47,6 @@
 
     rect.filled,
     rect.active.filled {
-      fill: #393;
       stroke-width: 0px;
     }
 

--- a/web/src/templates/schema.js
+++ b/web/src/templates/schema.js
@@ -94,6 +94,10 @@ const BitmapFields = {
     y: { $ref: "#/definitions/verticalPosition" },
     w: { title: "Width", $ref: "#/definitions/horizontalPosition" },
     h: { title: "Height", $ref: "#/definitions/verticalPosition" },
+    background_color: {
+        title: "Background Color",
+        $ref: "#/definitions/color"
+    },
     color: { $ref: "#/definitions/color" },
     value: {
       title: "Value",


### PR DESCRIPTION
![tenor](https://user-images.githubusercontent.com/20761757/77889610-fac6ab80-7222-11ea-8225-8ac126659520.gif)

And you thought you were rid of me.

Hasn't even been 24 hours.

---

Four main things:

1. The bitmap color changing does work! So you can have red-on-white/white-on-black bitmaps.

![image](https://user-images.githubusercontent.com/20761757/77889786-47aa8200-7223-11ea-919d-e1f2af703728.png)

Vs

![image](https://user-images.githubusercontent.com/20761757/77889816-509b5380-7223-11ea-9ec7-18548a688a30.png)

2. I need help getting two things working

    1. Background color showing up properly in the template editor
    2. Rectangle color properly filling when `filled` in the template editor

3. (Static?) Rectangles were not being rendered on boot without some change happening to them first. Adding `region->render()` to it being added to the region list solved that.
    - Should we instead of rendering text and bitmaps in their respective renderX functions, would it be better to create a temporary Region instance, run `region->render()`, and let the stack reclaim the memory? That way, we only have to change the render functions in one spot (and it looks nicer).

4. everything needs a fscking background color. I considered adding it to the Region parent class, but didn't have any luck... Would it be better to instead add it to the json object when passing it to the renderX functions?